### PR TITLE
Add support for builder.AddAppSettings

### DIFF
--- a/serilog-settings-combined.sln
+++ b/serilog-settings-combined.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E3A3B400-AD76-448B-A44B-A5D7314FAC44}"
 EndProject
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{C789B5
 		assets\Serilog.snk = assets\Serilog.snk
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestDummies", "test\TestDummies\TestDummies.csproj", "{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{20DF8798-4764-4213-BCF9-F0B55FABFDE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20DF8798-4764-4213-BCF9-F0B55FABFDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20DF8798-4764-4213-BCF9-F0B55FABFDE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{DA007207-F261-49ED-9ED1-24F709C53E77} = {E3A3B400-AD76-448B-A44B-A5D7314FAC44}
 		{20DF8798-4764-4213-BCF9-F0B55FABFDE9} = {D4CACEEA-2101-42BB-B3AC-16E685850988}
+		{CCCCC5CA-A2A1-444F-8FD3-19B2823228CB} = {D4CACEEA-2101-42BB-B3AC-16E685850988}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5DBD5279-7498-481B-92C0-829124A6E543}

--- a/serilog-settings-combined.sln.DotSettings
+++ b/serilog-settings-combined.sln.DotSettings
@@ -126,6 +126,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_TYPEOF_PARENTHESES/@EntryValue">False</s:Boolean>
@@ -537,9 +538,14 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/Serilog.Settings.Combined/AppSettingsSettingsBuilderExtensions.cs
+++ b/src/Serilog.Settings.Combined/AppSettingsSettingsBuilderExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if APPSETTINGS
+using System;
+using Serilog.Settings.AppSettings;
+using Serilog.Settings.Combined;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extensions to allow combination of settings originating from config file appSettings
+    /// </summary>
+    public static class AppSettingsSettingsBuilderExtensions
+    {
+        /// <summary>
+        /// Reads the &lt;appSettings&gt; element of App.config or Web.config, searching for keys
+        /// that look like: <code>serilog:*</code>, which are used to configure
+        /// the logger.
+        /// </summary>
+        /// <param name="builder">The combined settings builder</param>
+        /// <param name="settingPrefix">Prefix to use when reading keys in appSettings. If specified the value
+        /// will be prepended to the setting keys and followed by :, for example "myapp" will use "myapp:serilog:minumum-level. If null
+        /// no prefix is applied.</param>
+        /// <param name="filePath">Specify the path to an alternative .config file location. If the file does not exist it will be ignored.
+        /// By default, the current application's configuration file will be used.</param>
+        /// <returns>An object allowing configuration to continue.</returns>
+        public static ICombinedSettingsBuilder AddAppSettings(this ICombinedSettingsBuilder builder, string settingPrefix = null, string filePath = null)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            var appSettings = new AppSettingsSettings(settingPrefix, filePath);
+            builder.AddKeyValuePairs(appSettings.GetKeyValuePairs());
+            return builder;
+        }
+    }
+}
+#endif

--- a/src/Serilog.Settings.Combined/CombinedSettingsLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Settings.Combined/CombinedSettingsLoggerConfigurationExtensions.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Serilog.Configuration;
 using Serilog.Settings.Combined;
 

--- a/src/Serilog.Settings.Combined/Serilog.Settings.Combined.csproj
+++ b/src/Serilog.Settings.Combined/Serilog.Settings.Combined.csproj
@@ -25,7 +25,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.6.0-dev-00923" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>$(DefineConstants);APPSETTINGS</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/Serilog.Settings.Combined/Settings/AppSettings/AppSettingsSettings.cs
+++ b/src/Serilog.Settings.Combined/Settings/AppSettings/AppSettingsSettings.cs
@@ -11,18 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #if APPSETTINGS
 using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
-using Serilog.Configuration;
 using Serilog.Debugging;
 
 namespace Serilog.Settings.AppSettings
 {
-    class AppSettingsSettings : ILoggerSettings
+    class AppSettingsSettings
     {
         readonly string _filePath;
         readonly string _settingPrefix;
@@ -33,10 +33,8 @@ namespace Serilog.Settings.AppSettings
             _settingPrefix = settingPrefix == null ? "serilog:" : $"{settingPrefix}:serilog:";
         }
 
-        public void Configure(LoggerConfiguration loggerConfiguration)
+        public IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-
             IEnumerable<KeyValuePair<string, string>> settings;
 
             if (!string.IsNullOrWhiteSpace(_filePath))
@@ -44,10 +42,10 @@ namespace Serilog.Settings.AppSettings
                 if (!File.Exists(_filePath))
                 {
                     SelfLog.WriteLine("The specified configuration file `{0}` does not exist and will be ignored.", _filePath);
-                    return;
+                    return Enumerable.Empty<KeyValuePair<string, string>>();
                 }
 
-                var map = new ExeConfigurationFileMap {ExeConfigFilename = _filePath};
+                var map = new ExeConfigurationFileMap { ExeConfigFilename = _filePath };
                 var config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
                 settings = config.AppSettings.Settings
                     .Cast<KeyValueConfigurationElement>()
@@ -65,7 +63,7 @@ namespace Serilog.Settings.AppSettings
                     k.Key.Substring(_settingPrefix.Length),
                     Environment.ExpandEnvironmentVariables(k.Value)));
 
-            loggerConfiguration.ReadFrom.KeyValuePairs(pairs);
+            return pairs;
         }
     }
 }

--- a/src/Serilog.Settings.Combined/Settings/AppSettings/AppSettingsSettings.cs
+++ b/src/Serilog.Settings.Combined/Settings/AppSettings/AppSettingsSettings.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#if APPSETTINGS
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using Serilog.Configuration;
+using Serilog.Debugging;
+
+namespace Serilog.Settings.AppSettings
+{
+    class AppSettingsSettings : ILoggerSettings
+    {
+        readonly string _filePath;
+        readonly string _settingPrefix;
+
+        public AppSettingsSettings(string settingPrefix = null, string filePath = null)
+        {
+            _filePath = filePath;
+            _settingPrefix = settingPrefix == null ? "serilog:" : $"{settingPrefix}:serilog:";
+        }
+
+        public void Configure(LoggerConfiguration loggerConfiguration)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+
+            IEnumerable<KeyValuePair<string, string>> settings;
+
+            if (!string.IsNullOrWhiteSpace(_filePath))
+            {
+                if (!File.Exists(_filePath))
+                {
+                    SelfLog.WriteLine("The specified configuration file `{0}` does not exist and will be ignored.", _filePath);
+                    return;
+                }
+
+                var map = new ExeConfigurationFileMap {ExeConfigFilename = _filePath};
+                var config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
+                settings = config.AppSettings.Settings
+                    .Cast<KeyValueConfigurationElement>()
+                    .Select(k => new KeyValuePair<string, string>(k.Key, k.Value));
+            }
+            else
+            {
+                settings = ConfigurationManager.AppSettings.AllKeys
+                    .Select(k => new KeyValuePair<string, string>(k, ConfigurationManager.AppSettings[k]));
+            }
+
+            var pairs = settings
+                .Where(k => k.Key.StartsWith(_settingPrefix))
+                .Select(k => new KeyValuePair<string, string>(
+                    k.Key.Substring(_settingPrefix.Length),
+                    Environment.ExpandEnvironmentVariables(k.Value)));
+
+            loggerConfiguration.ReadFrom.KeyValuePairs(pairs);
+        }
+    }
+}
+#endif

--- a/src/Serilog.Settings.Combined/Settings/Combined/CombinedSettingsBuilder.cs
+++ b/src/Serilog.Settings.Combined/Settings/Combined/CombinedSettingsBuilder.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 
 namespace Serilog.Settings.Combined

--- a/test/Serilog.Settings.Combined.Tests/CombinedAppSettingsTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/CombinedAppSettingsTests.cs
@@ -1,0 +1,69 @@
+﻿#if APPSETTINGS
+using System.Linq;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using TestDummies;
+using Xunit;
+
+namespace Serilog.Settings.Combined.Tests
+{
+    public class CombinedAppSettingsTests
+    {
+        public CombinedAppSettingsTests()
+        {
+            DummyRollingFileSink.Reset();
+        }
+
+        [Fact]
+        public void CombinedCanMergeSettingsFromMultipleConfigFiles()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                        .AddAppSettings(filePath: "Samples/Initial.config")
+                        .AddAppSettings(filePath: "Samples/Second.config")
+                        .AddAppSettings(filePath: "Samples/Third.config")
+                    )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+            Assert.True(DummyRollingFileSink.Emitted.Any(), "Events should be written to DummyRollingFile");
+            Assert.Equal("DefinedInThird", DummyRollingFileSink.PathFormat);
+            Assert.Equal("DefinedInSecond", DummyRollingFileSink.OutputTemplate);
+
+            Assert.NotNull(evt);
+            Assert.Equal("OverridenInThird", evt.Properties["AppName"].LiteralValue());
+            Assert.Equal("DeclaredInSecond", evt.Properties["ServerName"].LiteralValue());
+        }
+
+        [Fact]
+        public void CombinedCanMergeAppSettingsWithInMemoryKeyValuePairs()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddKeyValuePair("minimum-level", "Verbose")
+                    .AddKeyValuePair("using:TestDummies", "TestDummies")
+                    .AddKeyValuePair("write-to:DummyRollingFile.restrictedToMinimumLevel", "Debug")
+                    .AddKeyValuePair("enrich:with-property:AppName", "DeclaredInKeyValuePairs")
+                    .AddAppSettings(filePath: "Samples/Second.config")
+                    .AddKeyValuePair("write-to:DummyRollingFile.pathFormat", "DefinedInKeyValuePairs")
+                    .AddKeyValuePair("enrich:with-property:AppName", "OverridenInKeyValuePairs")
+                )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+            Assert.True(DummyRollingFileSink.Emitted.Any(), "Events should be written to DummyRollingFile");
+            Assert.Equal("DefinedInKeyValuePairs", DummyRollingFileSink.PathFormat);
+            Assert.Equal("DefinedInSecond", DummyRollingFileSink.OutputTemplate);
+
+            Assert.NotNull(evt);
+            Assert.Equal("OverridenInKeyValuePairs", evt.Properties["AppName"].LiteralValue());
+            Assert.Equal("DeclaredInSecond", evt.Properties["ServerName"].LiteralValue());
+        }
+    }
+}
+
+#endif

--- a/test/Serilog.Settings.Combined.Tests/CombinedSettingsMixTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/CombinedSettingsMixTests.cs
@@ -1,0 +1,41 @@
+#if APPSETTINGS
+using System.Linq;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using TestDummies;
+using Xunit;
+
+namespace Serilog.Settings.Combined.Tests
+{
+    public class CombinedSettingsMixTests
+    {
+        [Fact]
+        public void CombinedCanMixAndMatchMultipleSources()
+        {
+            LogEvent evt = null;
+            // typical scenario : doing most of the config in code / default value
+            // .... and override a few things from config files
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddKeyValuePair("minimum-level", "Verbose")
+                    .AddKeyValuePair("enrich:with-property:AppName", "DeclaredInInitial")
+                    .AddKeyValuePair("using:TestDummies" ,"TestDummies")
+                    .AddKeyValuePair("write-to:DummyRollingFile.pathFormat", "DeclaredInInitial")
+                    .AddAppSettings(filePath: "Samples/ConfigOverrides.config")
+                    .AddKeyValuePair("enrich:with-property:ExtraProp", "AddedAtTheVeryEnd")
+                )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+            Assert.True(DummyRollingFileSink.Emitted.Any(), "Events should be written to DummyRollingFile");
+            Assert.Equal("DefinedInConfigFile", DummyRollingFileSink.PathFormat);
+
+            Assert.NotNull(evt);
+            Assert.Equal("DeclaredInInitial", evt.Properties["AppName"].LiteralValue());
+            Assert.Equal("DeclaredInConfigFile", evt.Properties["ServerName"].LiteralValue());
+            Assert.Equal("AddedAtTheVeryEnd", evt.Properties["ExtraProp"].LiteralValue());
+        }
+    }
+}
+#endif

--- a/test/Serilog.Settings.Combined.Tests/Samples/ConfigOverrides.config
+++ b/test/Serilog.Settings.Combined.Tests/Samples/ConfigOverrides.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="serilog:write-to:DummyRollingFile.pathFormat" value="DefinedInConfigFile" />
+    <add key="serilog:enrich:with-property:ServerName" value="DeclaredInConfigFile" />
+  </appSettings>
+</configuration>

--- a/test/Serilog.Settings.Combined.Tests/Samples/Initial.config
+++ b/test/Serilog.Settings.Combined.Tests/Samples/Initial.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="serilog:minimum-level" value="Verbose" />
+    <add key="serilog:using:TestDummies" value="TestDummies" />
+    <add key="serilog:write-to:DummyRollingFile.restrictedToMinimumLevel" value="Debug" />
+    <!-- DummyRollingFile.pathFormat intentionnaly left empty here, to be declared later-->
+    <!-- DummyRollingFile.outputTemplate intentionnaly left empty here, to be declared later-->
+    <add key="serilog:enrich:with-property:AppName" value="DeclaredInInitial" />
+  </appSettings>
+</configuration>

--- a/test/Serilog.Settings.Combined.Tests/Samples/Second.config
+++ b/test/Serilog.Settings.Combined.Tests/Samples/Second.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="serilog:write-to:DummyRollingFile.outputTemplate" value="DefinedInSecond" />
+    <add key="serilog:enrich:with-property:ServerName" value="DeclaredInSecond" />
+  </appSettings>
+</configuration>

--- a/test/Serilog.Settings.Combined.Tests/Samples/Third.config
+++ b/test/Serilog.Settings.Combined.Tests/Samples/Third.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="serilog:write-to:DummyRollingFile.pathFormat" value="DefinedInThird" />
+    <add key="serilog:enrich:with-property:AppName" value="OverridenInThird" />
+  </appSettings>
+</configuration>

--- a/test/Serilog.Settings.Combined.Tests/Serilog.Settings.Combined.Tests.csproj
+++ b/test/Serilog.Settings.Combined.Tests/Serilog.Settings.Combined.Tests.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Settings.Combined.Tests</AssemblyName>
     <PackageId>Serilog.Settings.Combined.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -18,12 +12,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Settings.Combined\Serilog.Settings.Combined.csproj" />
+    <ProjectReference Include="..\TestDummies\TestDummies.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <DefineConstants>$(DefineConstants);APPSETTINGS</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/test/Serilog.Settings.Combined.Tests/Serilog.Settings.Combined.Tests.csproj
+++ b/test/Serilog.Settings.Combined.Tests/Serilog.Settings.Combined.Tests.csproj
@@ -11,6 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Samples\*.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Samples\*.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/test/Serilog.Settings.Combined.Tests/Support/Formatting/CustomFormatters.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/Formatting/CustomFormatters.cs
@@ -1,0 +1,10 @@
+﻿using Serilog.Formatting;
+
+namespace Serilog.Settings.Combined.Tests.Support.Formatting
+{
+    public static class CustomFormatters
+    {
+        public static ITextFormatter Formatter { get; } = new MyCustomTextFormatter();
+        public static ITextFormatter FormatterField = new MyCustomTextFormatter();
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/Support/Formatting/MyCustomTextFormatter.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/Formatting/MyCustomTextFormatter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Settings.Combined.Tests.Support.Formatting
+{
+    public class MyCustomTextFormatter : ITextFormatter
+    {
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/Support/KeyValuePairComparer.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/KeyValuePairComparer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Settings.Combined.Tests.Support
+{
+    public class KeyValuePairComparer<TK, TValue> : IEqualityComparer<KeyValuePair<TK, TValue>>
+    {
+        public bool Equals(KeyValuePair<TK, TValue> x, KeyValuePair<TK, TValue> y)
+        {
+            return x.Key.Equals(y.Key) && x.Value.Equals(y.Value);
+        }
+
+        public int GetHashCode(KeyValuePair<TK, TValue> obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
+}

--- a/test/Serilog.Settings.Combined.Tests/Support/MyCustomConsoleTheme.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/MyCustomConsoleTheme.cs
@@ -1,0 +1,8 @@
+﻿using TestDummies.Console.Themes;
+
+namespace Serilog.Settings.Combined.Tests.Support
+{
+    public class MyCustomConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/Support/Some.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/Some.cs
@@ -72,6 +72,11 @@ namespace Serilog.Tests.Support
             return LogEvent(timestamp, LogEventLevel.Warning);
         }
 
+        public static LogEvent ErrorEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Error);
+        }
+
         public static LogEventProperty LogEventProperty()
         {
             return new LogEventProperty(String(), new ScalarValue(Int()));

--- a/test/Serilog.Settings.Combined.Tests/Support/TemporarySelfLog.cs
+++ b/test/Serilog.Settings.Combined.Tests/Support/TemporarySelfLog.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Debugging;
+using Xunit.Abstractions;
+
+namespace Serilog.Tests.Support
+{
+    public class TemporarySelfLog : IDisposable
+    {
+        TemporarySelfLog(Action<string> output)
+        {
+            SelfLog.Enable(output);
+        }
+
+        public void Dispose()
+        {
+            SelfLog.Disable();
+        }
+
+        public static IDisposable SaveTo(List<string> target)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            return new TemporarySelfLog(target.Add);
+        }
+
+        public static IDisposable WriteToXunitOutput(ITestOutputHelper outputHelper)
+        {
+            if (outputHelper == null) throw new ArgumentNullException(nameof(outputHelper));
+
+            return new TemporarySelfLog(outputHelper.WriteLine);
+        }
+    }
+}

--- a/test/TestDummies/Console/DummyConsoleSink.cs
+++ b/test/TestDummies/Console/DummyConsoleSink.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using TestDummies.Console.Themes;
+
+namespace TestDummies.Console
+{
+    public class DummyConsoleSink : ILogEventSink
+    {
+        public DummyConsoleSink(ConsoleTheme theme = null)
+        {
+            Theme = theme ?? ConsoleTheme.None;
+        }
+
+        [ThreadStatic]
+        public static ConsoleTheme Theme;
+
+        public void Emit(LogEvent logEvent)
+        {
+        }
+
+        public static void Reset()
+        {
+            Theme = null;
+        }
+    }
+
+}
+

--- a/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class ConcreteConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConsoleTheme.cs
@@ -1,0 +1,7 @@
+namespace TestDummies.Console.Themes
+{
+    public abstract class ConsoleTheme
+    {
+        public static ConsoleTheme None { get; } = new EmptyConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleThemes.cs
+++ b/test/TestDummies/Console/Themes/ConsoleThemes.cs
@@ -1,0 +1,8 @@
+namespace TestDummies.Console.Themes
+{
+    public static class ConsoleThemes
+    {
+        public static ConsoleTheme Theme1 { get; } = new ConcreteConsoleTheme();
+        public static ConsoleTheme Theme1Field = new ConcreteConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class EmptyConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Configuration;
+using Serilog.Core;
+using TestDummies.Console;
+using TestDummies.Console.Themes;
+
+namespace TestDummies
+{
+    public static class DummyLoggerConfigurationExtensions
+    {
+        public static LoggerConfiguration WithDummyThreadId(this LoggerEnrichmentConfiguration enrich)
+        {
+            return enrich.With(new DummyThreadIdEnricher());
+        }
+
+        public static LoggerConfiguration WithDummyUserName(this LoggerEnrichmentConfiguration enrich, string extraParam)
+        {
+            return enrich.With(new DummyUserNameEnricher(extraParam));
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(pathFormat, outputTemplate), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            ITextFormatter formatter,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(pathFormat, null), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerAuditSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileAuditSink(pathFormat, outputTemplate), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyWithFormatter(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            ITextFormatter formatter = null
+        )
+        {
+            return loggerSinkConfiguration.Sink(new DummySink(null, 0, null, null, formatter),
+                restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyWithLevelSwitch(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch controlLevelSwitch = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyWithLevelSwitchSink(controlLevelSwitch), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyConsole(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            ConsoleTheme theme = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel);
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileAuditSink : ILogEventSink
+    {
+        public DummyRollingFileAuditSink(string pathFormat, string outputTemplate)
+        {
+            PathFormat = pathFormat;
+            OutputTemplate = outputTemplate;
+        }
+
+        [ThreadStatic]
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted
+        {
+            get
+            {
+                if (_emitted == null)
+                {
+                    _emitted = new List<LogEvent>();
+                }
+                return _emitted;
+            }
+        }
+
+        [ThreadStatic]
+        public static string OutputTemplate;
+
+        [ThreadStatic]
+        public static string PathFormat;
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
+            OutputTemplate = null;
+            PathFormat = null;
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileSink : ILogEventSink
+    {
+        public DummyRollingFileSink(string pathFormat, string outputTemplate)
+        {
+            PathFormat = pathFormat;
+            OutputTemplate = outputTemplate;
+        }
+
+        [ThreadStatic]
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted
+        {
+            get
+            {
+                if (_emitted == null)
+                {
+                    _emitted = new List<LogEvent>();
+                }
+                return _emitted;
+            }
+        }
+
+        [ThreadStatic]
+        public static string OutputTemplate;
+
+        [ThreadStatic]
+        public static string PathFormat;
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
+            OutputTemplate = null;
+            PathFormat = null;
+        }
+    }
+}

--- a/test/TestDummies/DummySink.cs
+++ b/test/TestDummies/DummySink.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace TestDummies
+{
+    /// <summary>
+    /// Just a dummy sink that allows to verify that the proper params are passed from configuration
+    /// </summary>
+    public class DummySink : ILogEventSink
+    {
+
+        public DummySink(string stringParam, int intParam, string stringParamWithDefault, int? nullableIntParam, ITextFormatter formatter)
+        {
+            StringParam = stringParam;
+            IntParam = intParam;
+            StringParamWithDefault = stringParamWithDefault;
+            NullableIntParam = nullableIntParam;
+            Formatter = formatter;
+        }
+
+        [ThreadStatic]
+        public static ITextFormatter Formatter;
+        [ThreadStatic]
+        public static string StringParam;
+        [ThreadStatic]
+        public static int IntParam;
+        [ThreadStatic]
+        public static string StringParamWithDefault;
+        [ThreadStatic]
+        public static int? NullableIntParam;
+
+        [ThreadStatic]
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted
+        {
+            get
+            {
+                if (_emitted == null)
+                {
+                    _emitted = new List<LogEvent>();
+                }
+                return _emitted;
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            Formatter = null;
+            IntParam = default(int);
+            NullableIntParam = null;
+            StringParam = null;
+            StringParamWithDefault = null;
+            _emitted = null;
+        }
+    }
+}

--- a/test/TestDummies/DummyThreadIdEnricher.cs
+++ b/test/TestDummies/DummyThreadIdEnricher.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyThreadIdEnricher : ILogEventEnricher
+    {
+        public const string PropertyName = "ThreadId";
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(PropertyName, Guid.NewGuid()));
+        }
+    }
+}

--- a/test/TestDummies/DummyUserNameEnricher.cs
+++ b/test/TestDummies/DummyUserNameEnricher.cs
@@ -1,0 +1,25 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyUserNameEnricher : ILogEventEnricher
+    {
+        public const string PropertyName = "UserName";
+
+        readonly string _userName;
+
+        public DummyUserNameEnricher(string userName)
+        {
+            _userName = userName;
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (_userName != null)
+            {
+                logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(PropertyName, _userName));
+            }
+        }
+    }
+}

--- a/test/TestDummies/DummyWithLevelSwitchSink.cs
+++ b/test/TestDummies/DummyWithLevelSwitchSink.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyWithLevelSwitchSink : ILogEventSink
+    {
+        public DummyWithLevelSwitchSink(LoggingLevelSwitch loggingControlLevelSwitch)
+        {
+            ControlLevelSwitch = loggingControlLevelSwitch;
+        }
+
+        [ThreadStatic]
+        public static LoggingLevelSwitch ControlLevelSwitch;
+
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace TestDummies
+{
+    public class DummyWrappingSink : ILogEventSink
+    {
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        private readonly ILogEventSink _sink;
+
+        public DummyWrappingSink(ILogEventSink sink)
+        {
+            _sink = sink;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+            _sink.Emit(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/Properties/AssemblyInfo.cs
+++ b/test/TestDummies/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestDummies")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2bb12ce5-c867-43bd-ae5d-253fe3248c7f")]

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <AssemblyName>TestDummies</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>TestDummies</PackageId>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
First part of #5 : **AppSettings**

Support for loading key value pairs from an arbitrary config file.

Notes : 
- The `AppSettingsSettings.cs` file has been copied and adapted from *Serilog.Settings.AppSettings* for now. 
- All the *AppSettings* related part is surrounded with `#if APPSETTINGS` to make it available only on full framework for now. I don't know if that could be problematic and if there is a better way
- This is a "repackaging" of a bigger bunch of commits, and to make things easier, I have put all the creation of Test support stuff (*TestDummies*, *Tests.Support* etc) in the first commit.
