### PR TITLE
Add support for builder.AddExpression

### DIFF
--- a/src/Serilog.Settings.Combined/ConfigExpressionSettingsBuilderExtensions.cs
+++ b/src/Serilog.Settings.Combined/ConfigExpressionSettingsBuilderExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq.Expressions;
+using Serilog.Settings.Combined;
+using Serilog.Settings.ConfigExpression;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extensions to allow combination of settings originating from config file appSettings
+    /// </summary>
+    public static class ConfigExpressionSettingsBuilderExtensions
+    {
+        /// <summary>
+        /// Converts a configuration expression into a series of key-value pairs and add them to the pool of available settings
+        /// </summary>
+        /// <param name="builder">The combined settings builder</param>
+        /// <param name="loggerConfigExpression">A configuration expression</param>
+        /// <returns>An object allowing configuration to continue.</returns>
+        public static ICombinedSettingsBuilder AddExpression(this ICombinedSettingsBuilder builder, Expression<Func<LoggerConfiguration, LoggerConfiguration>> loggerConfigExpression)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (loggerConfigExpression == null) throw new ArgumentNullException(nameof(loggerConfigExpression));
+
+            var serializer = new ConfigurationExpressionSettingsSerializer();
+            var keyValuePairs = serializer.SerializeToKeyValuePairs(loggerConfigExpression);
+
+            return builder.AddKeyValuePairs(keyValuePairs);
+        }
+    }
+}

--- a/src/Serilog.Settings.Combined/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializer.cs
+++ b/src/Serilog.Settings.Combined/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializer.cs
@@ -1,0 +1,275 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Serilog.Configuration;
+using Serilog.Events;
+
+namespace Serilog.Settings.ConfigExpression
+{
+    class ConfigurationExpressionSettingsSerializer
+    {
+        public IEnumerable<KeyValuePair<string, string>> SerializeToKeyValuePairs(Expression<Func<LoggerConfiguration, LoggerConfiguration>> expression)
+        {
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
+            var methodCallExpression = expression.Body as MethodCallExpression ?? throw new ArgumentException("Expression's body should be a Method call", $"{nameof(expression)}.{nameof(expression.Body)}");
+            return WalkFluentMethodCallsFromRightToLeft(methodCallExpression)
+                .Reverse()
+                .SelectMany(x => x);
+        }
+
+        static IEnumerable<List<KeyValuePair<string, string>>> WalkFluentMethodCallsFromRightToLeft(MethodCallExpression methodCallExp)
+        {
+            if (methodCallExp == null) throw new ArgumentNullException(nameof(methodCallExp));
+
+            Expression current = methodCallExp;
+
+            while (current is MethodCallExpression)
+            {
+                var methodCall = (MethodCallExpression)current;
+                var method = methodCall.Method;
+                var methodName = method.Name;
+                var (methodTarget, normalizedMethodArguments) = ExtractNormalizedTargetAndArguments(methodCall);
+
+                current = methodTarget.Expression;
+
+                switch (methodTarget.Member.Name)
+                {
+                    case nameof(LoggerConfiguration.MinimumLevel):
+                        // .MinimumLevel.Override(string namespace, LogEventLevel overridenLevel)
+                        if (methodName == nameof(LoggerMinimumLevelConfiguration.Override))
+                        {
+                            var overrideNamespace = ((ConstantExpression)normalizedMethodArguments[0]).Value.ToString();
+                            var overrideLevel = ConvertExpressionToSettingValue(normalizedMethodArguments[1], typeof(LogEventLevel));
+
+                            yield return new List<KeyValuePair<string, string>>
+                            {
+                                new KeyValuePair<string, string>(SettingsDirectives.MinimumLevelOverride(overrideNamespace), overrideLevel)
+                            };
+                            continue;
+                        }
+
+                        // .MinimumLevel.Is(LogEventLevel level)
+                        if (methodName == nameof(LoggerMinimumLevelConfiguration.Is))
+                        {
+                            var minimumLevelIs = ConvertExpressionToSettingValue(normalizedMethodArguments[0], typeof(LogEventLevel));
+                            yield return new List<KeyValuePair<string, string>>
+                            {
+                                new KeyValuePair<string, string>(SettingsDirectives.MinimumLevel, minimumLevelIs)
+                            };
+                            continue;
+                        }
+
+                        // .MinimumLevel.Debug(), MinimumLevel.Information() etc ...
+                        if (!Enum.TryParse(methodName, out LogEventLevel minimumLevel))
+                            throw new NotImplementedException($"Not supported : MinimumLevel.{methodName}");
+
+                        yield return new List<KeyValuePair<string, string>>
+                        {
+                            new KeyValuePair<string, string>(SettingsDirectives.MinimumLevel, minimumLevel.ToString())
+                        };
+                        continue;
+
+                    case nameof(LoggerConfiguration.Enrich):
+                        // .Enrich.WithProperty(string propertyName, object propertyValue, bool destructureObjects)
+                        if (methodName == nameof(LoggerEnrichmentConfiguration.WithProperty))
+                        {
+                            var enrichPropertyName = ((ConstantExpression)normalizedMethodArguments[0]).Value.ToString();
+                            var enrichWithArgument = normalizedMethodArguments[1];
+                            var enrichmentValue = ConvertExpressionToSettingValue(enrichWithArgument, typeof(object));
+                            yield return new List<KeyValuePair<string, string>>
+                            {
+                                new KeyValuePair<string, string>(SettingsDirectives.EnrichWithProperty(enrichPropertyName), enrichmentValue)
+                            };
+                            continue;
+                        }
+
+                        // method .Enrich.FromLogContext()
+                        // or extension method .Enrich.WithBar(param1, param2)
+                        yield return SerializeMethodInvocation(MethodInvocationType.Enrich, method, normalizedMethodArguments);
+                        continue;
+
+                    case nameof(LoggerConfiguration.WriteTo):
+                        // method .WriteTo.Sink()
+                        // or extension method .WriteTo.CustomSink(param1, param2)
+                        yield return SerializeMethodInvocation(MethodInvocationType.WriteTo, method, normalizedMethodArguments);
+                        continue;
+                    case nameof(LoggerConfiguration.AuditTo):
+                        // method .AuditTo.Sink()
+                        // or extension method .AuditTo.CustomSink(param1, param2)
+                        yield return SerializeMethodInvocation(MethodInvocationType.AuditTo, method, normalizedMethodArguments);
+                        continue;
+                    case nameof(LoggerConfiguration.Filter):
+                        // extension method .Filter.ByCustomMethod(param1, param2)
+                        yield return SerializeMethodInvocation(MethodInvocationType.Filter, method, normalizedMethodArguments);
+                        continue;
+                    default:
+                        throw new NotSupportedException($"Not supported : LoggerConfiguration.{methodTarget.Member.Name}");
+                }
+            }
+        }
+
+        static List<KeyValuePair<string, string>> SerializeMethodInvocation(MethodInvocationType methodInvocationType, MethodInfo method, IReadOnlyList<Expression> normalizedMethodArguments)
+        {
+            var methodName = method.Name;
+            var normalizedMethodParameters = ExtractNormalizedParameters(method);
+            var resultingDirectives = new List<KeyValuePair<string, string>>();
+            // using  
+            var usingDirectives = GetUsingDirectivesForMethodCall(method);
+            resultingDirectives.AddRange(usingDirectives);
+            var args = normalizedMethodArguments
+                .Zip(normalizedMethodParameters, (expression, param) => new
+                {
+                    MethodArgument = expression,
+                    Parameter = param
+                })
+                .Select(x => new
+                {
+                    ParamName = x.Parameter.Name,
+                    ParamValue = ConvertExpressionToSettingValue(x.MethodArgument, x.Parameter.ParameterType)
+                })
+                .Where(x => x.ParamValue != null);
+
+            var directives = args.Select(x => new KeyValuePair<string, string>(SettingsDirectives.MethodInvocationParameter(methodInvocationType, methodName, x.ParamName), x.ParamValue)).ToList();
+            if (directives.Count > 0)
+            {
+                resultingDirectives.AddRange(directives);
+            }
+            else
+            {
+                resultingDirectives.Add(new KeyValuePair<string, string>(SettingsDirectives.ParameterlessMethodInvocation(methodInvocationType, methodName), ""));
+            }
+            return resultingDirectives;
+        }
+
+        static IEnumerable<KeyValuePair<string, string>> GetUsingDirectivesForMethodCall(MethodInfo method)
+        {
+            var containingAssembly = method.DeclaringType.GetTypeInfo().Assembly;
+            if (containingAssembly == typeof(ILogger).GetTypeInfo().Assembly)
+            {
+                // no using is required for Serilog assembly
+                yield break;
+            }
+            var assemblyShortName = containingAssembly.GetName().Name;
+
+            yield return new KeyValuePair<string, string>(SettingsDirectives.Using(assemblyShortName), $"{assemblyShortName}");
+        }
+
+        /// <summary>
+        /// Extract target and parameters in a consistent way, whether method is a "regular" method call
+        /// or an extension method (actually a sttic method where the first parameter is the target)
+        /// </summary>
+        /// <returns></returns>
+        static (MemberExpression target, IReadOnlyList<Expression> normalizedArguments) ExtractNormalizedTargetAndArguments(MethodCallExpression methodCall)
+        {
+            var method = methodCall.Method;
+            MemberExpression leftSide;
+            List<Expression> methodArguments;
+            if (method.IsStatic)
+            {
+                // extension method : the first argument is the target
+                leftSide = (MemberExpression)methodCall.Arguments[0];
+                methodArguments = methodCall.Arguments.Skip(1).ToList();
+            }
+            else
+            {
+                // regular method 
+                leftSide = (MemberExpression)methodCall.Object;
+                methodArguments = methodCall.Arguments.ToList();
+            }
+
+            return (target: leftSide, normalizedArguments: methodArguments.AsReadOnly());
+        }
+
+        static IReadOnlyList<ParameterInfo> ExtractNormalizedParameters(MethodInfo method)
+        {
+            if (method.IsStatic)
+            {
+                // extension method : the first parameter is actually the target !
+                return method.GetParameters().Skip(1).ToList().AsReadOnly();
+            }
+
+            return method.GetParameters().ToList().AsReadOnly();
+        }
+
+        static string ConvertExpressionToSettingValue(Expression exp, Type targetParameterType)
+        {
+            if (exp == null) throw new ArgumentNullException(nameof(exp));
+            if (targetParameterType == null) throw new ArgumentNullException(nameof(targetParameterType));
+
+            if (exp is ConstantExpression constantExp)
+            {
+                return constantExp.Value == null ? null : $"{constantExp.Value}";
+            }
+
+            var targetTypeInfo = targetParameterType.GetTypeInfo();
+            if (targetTypeInfo.IsAbstract || targetTypeInfo.IsInterface)
+            {
+                // when target type is abstract, we support :
+                // calling the default constructor of an implementation
+                if (exp is NewExpression newExp && !newExp.Arguments.Any())
+                {
+                    return newExp.Type.AssemblyQualifiedName;
+                }
+
+                // accessing a public static property/field of that type
+                if (exp is MemberExpression memberExp)
+                {
+                    var propertyOrFieldInfo = memberExp.Member;
+                    var memberOwner = propertyOrFieldInfo.DeclaringType;
+                    if (propertyOrFieldInfo is PropertyInfo propInfo)
+                    {
+                        if (!(propInfo.GetMethod.IsPublic && propInfo.GetMethod.IsStatic))
+                        {
+                            throw new NotSupportedException($"Property {memberOwner.FullName}.{propInfo.Name} is not public static. Only public static properties are supported");
+                        }
+                    }
+
+                    if (propertyOrFieldInfo is FieldInfo fieldInfo)
+                    {
+                        if (!(fieldInfo.IsPublic && fieldInfo.IsStatic))
+                        {
+                            throw new NotSupportedException($"Field {memberOwner.FullName}.{fieldInfo.Name} is not public static. Only public static fields are supported");
+                        }
+                    }
+
+                    return $"{memberOwner.FullName}::{propertyOrFieldInfo.Name}, {memberOwner.GetTypeInfo().Assembly.FullName}";
+                }
+
+                throw new NotSupportedException($"Not supported : {exp.GetType()} `{exp}`");
+            }
+            switch (exp)
+            {
+                // a boolean is a UnaryExpression Convert(true), for some reason 
+                case UnaryExpression unaryExp:
+                    return $"{unaryExp.Operand}";
+
+                case NewExpression newExp:
+                    // constructor new Uri(string uri)
+                    if (newExp.Type == typeof(Uri))
+                    {
+                        return ((ConstantExpression)newExp.Arguments[0]).Value.ToString();
+                    }
+                    throw new NotImplementedException($"Not supported : new {newExp.Type}(...)");
+
+                default:
+                    throw new NotImplementedException($"Cannot extract a string value from `{exp}`");
+            }
+        }
+    }
+}

--- a/src/Serilog.Settings.Combined/Settings/ConfigExpression/SettingsDirectives.cs
+++ b/src/Serilog.Settings.Combined/Settings/ConfigExpression/SettingsDirectives.cs
@@ -1,0 +1,101 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Settings.ConfigExpression
+{
+    static class SettingsDirectives
+    {
+        const string UsingDirective = "using";
+        const string LevelSwitchDirective = "level-switch";
+        const string AuditToDirective = "audit-to";
+        const string WriteToDirective = "write-to";
+        const string MinimumLevelDirective = "minimum-level";
+        const string MinimumLevelControlledByDirective = "minimum-level:controlled-by";
+        const string EnrichWithDirective = "enrich";
+        const string EnrichWithPropertyDirective = "enrich:with-property";
+        const string FilterDirective = "filter";
+
+        public static string Using(string assemblyShortName)
+        {
+            if (assemblyShortName == null) throw new ArgumentNullException(nameof(assemblyShortName));
+            return $"{UsingDirective}:{assemblyShortName}";
+        }
+
+        public static string MinimumLevel = MinimumLevelDirective;
+
+        public static string MinimumLevelOverride(string namespacePrefix)
+        {
+            if (namespacePrefix == null) throw new ArgumentNullException(nameof(namespacePrefix));
+
+            return $"{MinimumLevelDirective}:override:{namespacePrefix}";
+        }
+
+        public static string EnrichWithProperty(string propertyName)
+        {
+            if (propertyName == null) throw new ArgumentNullException(nameof(propertyName));
+            return $"{EnrichWithPropertyDirective}:{propertyName}";
+        }
+
+        public static string ParameterlessMethodInvocation(MethodInvocationType invocationType, string methodName)
+        {
+            if (methodName == null) throw new ArgumentNullException(nameof(methodName));
+            string directivePrefix = GetDirectivePrefix(invocationType);
+
+            return $"{directivePrefix}:{methodName}";
+        }
+
+        public static string MethodInvocationParameter(MethodInvocationType invocationType, string methodName, string parameterName)
+        {
+            if (methodName == null) throw new ArgumentNullException(nameof(methodName));
+            if (parameterName == null) throw new ArgumentNullException(nameof(parameterName));
+            var directivePrefix = GetDirectivePrefix(invocationType);
+
+            return $"{directivePrefix}:{methodName}.{parameterName}";
+        }
+
+        static string GetDirectivePrefix(MethodInvocationType invocationType)
+        {
+            string directivePrefix;
+            switch (invocationType)
+            {
+                case MethodInvocationType.WriteTo:
+                    directivePrefix = WriteToDirective;
+                    break;
+                case MethodInvocationType.Enrich:
+                    directivePrefix = EnrichWithDirective;
+                    break;
+                case MethodInvocationType.AuditTo:
+                    directivePrefix = AuditToDirective;
+                    break;
+                case MethodInvocationType.Filter:
+                    directivePrefix = FilterDirective;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(invocationType), invocationType, "Unsupported Invocation type");
+            }
+
+            return directivePrefix;
+        }
+    }
+
+    enum MethodInvocationType
+    {
+        WriteTo,
+        AuditTo,
+        Enrich,
+        Filter
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/CombinedConfigExpressionSettingsTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/CombinedConfigExpressionSettingsTests.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using TestDummies;
+using Xunit;
+
+namespace Serilog.Settings.Combined.Tests
+{
+    public class CombinedConfigExpressionSettingsTests
+    {
+        public CombinedConfigExpressionSettingsTests()
+        {
+            DummyRollingFileSink.Reset();
+        }
+
+        [Fact]
+        public void CombinedCanMergeSettingsFromMultipleConfigExpressions()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddExpression(lc => lc
+                        .MinimumLevel.Verbose()
+                        .Enrich.WithProperty("AppName", "DeclaredInInitial", /*destructureObjects:*/ false)
+                        .WriteTo.DummyRollingFile(/*pathFormat*/ null, LogEventLevel.Debug, /*outputTemplate*/ null, /*formatProvider*/ null)
+                    )
+                    .AddExpression(lc => lc
+                        .Enrich.WithProperty("ServerName", "DeclaredInSecond", /*destructureObjects:*/ false)
+                        .WriteTo.DummyRollingFile(/*pathFormat*/ null, LogEventLevel.Debug, /*outputTemplate*/ "DefinedInSecond", /*formatProvider*/null)
+                    )
+                    .AddExpression(lc => lc
+                        .Enrich.WithProperty("AppName", "OverridenInThird", /*destructureObjects:*/ false)
+                        .WriteTo.DummyRollingFile(/*pathFormat*/ "DefinedInThird", LogEventLevel.Debug, /*outputTemplate*/ null, /*formatProvider*/null)
+                    )
+                )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+            Assert.True(DummyRollingFileSink.Emitted.Any(), "Events should be written to DummyRollingFile");
+            Assert.Equal("DefinedInThird", DummyRollingFileSink.PathFormat);
+            Assert.Equal("DefinedInSecond", DummyRollingFileSink.OutputTemplate);
+
+            Assert.NotNull(evt);
+            Assert.Equal("OverridenInThird", evt.Properties["AppName"].LiteralValue());
+            Assert.Equal("DeclaredInSecond", evt.Properties["ServerName"].LiteralValue());
+        }
+
+        [Fact]
+        public void CombinedCanMergeConfigExpressionWithInMemoryKeyValuePairs()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddKeyValuePair("minimum-level", "Verbose")
+                    .AddKeyValuePair("using:TestDummies", "TestDummies")
+                    .AddKeyValuePair("write-to:DummyRollingFile.restrictedToMinimumLevel", "Debug")
+                    .AddKeyValuePair("enrich:with-property:AppName", "DeclaredInKeyValuePairs")
+                    .AddExpression(lc => lc
+                        .Enrich.WithProperty("ServerName", "DeclaredInSecond", /*destructureObjects:*/ false)
+                        .WriteTo.DummyRollingFile(/*pathFormat*/ null, LogEventLevel.Debug, /*outputTemplate*/ "DefinedInSecond", /*formatProvider*/null)
+                    )
+                    .AddKeyValuePair("write-to:DummyRollingFile.pathFormat", "DefinedInKeyValuePairs")
+                    .AddKeyValuePair("enrich:with-property:AppName", "OverridenInKeyValuePairs")
+                )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+            Assert.True(DummyRollingFileSink.Emitted.Any(), "Events should be written to DummyRollingFile");
+            Assert.Equal("DefinedInKeyValuePairs", DummyRollingFileSink.PathFormat);
+            Assert.Equal("DefinedInSecond", DummyRollingFileSink.OutputTemplate);
+
+            Assert.NotNull(evt);
+            Assert.Equal("OverridenInKeyValuePairs", evt.Properties["AppName"].LiteralValue());
+            Assert.Equal("DeclaredInSecond", evt.Properties["ServerName"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/CombinedSettingsMixTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/CombinedSettingsMixTests.cs
@@ -17,10 +17,11 @@ namespace Serilog.Settings.Combined.Tests
             // .... and override a few things from config files
             var log = new LoggerConfiguration()
                 .ReadFrom.Combined(builder => builder
-                    .AddKeyValuePair("minimum-level", "Verbose")
-                    .AddKeyValuePair("enrich:with-property:AppName", "DeclaredInInitial")
-                    .AddKeyValuePair("using:TestDummies" ,"TestDummies")
-                    .AddKeyValuePair("write-to:DummyRollingFile.pathFormat", "DeclaredInInitial")
+                    .AddExpression(lc => lc
+                        .MinimumLevel.Verbose()
+                        .Enrich.WithProperty("AppName", "DeclaredInInitial", /*destructureObjects:*/ false)
+                        .WriteTo.DummyRollingFile(/*Formatter*/ null, /*pathFormat*/ "overridenInConfigFile", /*restrictedToMinimumLevel*/ LogEventLevel.Verbose)
+                    )
                     .AddAppSettings(filePath: "Samples/ConfigOverrides.config")
                     .AddKeyValuePair("enrich:with-property:ExtraProp", "AddedAtTheVeryEnd")
                 )

--- a/test/Serilog.Settings.Combined.Tests/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializerSanityTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializerSanityTests.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using Serilog.Context;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Settings.Combined.Tests.Support;
+using Serilog.Settings.Combined.Tests.Support.Formatting;
+using Serilog.Tests.Support;
+using TestDummies;
+using TestDummies.Console;
+using TestDummies.Console.Themes;
+using Xunit;
+
+using ConfigExpr = System.Linq.Expressions.Expression<System.Func<Serilog.LoggerConfiguration, Serilog.LoggerConfiguration>>;
+
+namespace Serilog.Settings.Combined.Tests.Settings.ConfigExpression
+{
+    public class ConfigurationExpressionSettingsSerializerSanityTests
+    {
+        [Fact]
+        public void MinimumLevel()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .MinimumLevel.Warning();
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+               {
+                   evt = null;
+                   return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+               },
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.Null(evt);
+                    logger.Write(Some.WarningEvent());
+                    Assert.NotNull(evt);
+                });
+        }
+
+        [Fact]
+        public void MinimumLevelIs()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .MinimumLevel.Is(LogEventLevel.Warning);
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.Null(evt);
+                    logger.Write(Some.WarningEvent());
+                    Assert.NotNull(evt);
+                });
+        }
+
+        [Fact]
+        public void MinimumLevelOverride()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .MinimumLevel.Verbose()
+                .MinimumLevel.Override("System.Collections", LogEventLevel.Error)
+                .MinimumLevel.Override("System", LogEventLevel.Warning);
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.NotNull(evt);
+
+                    evt = null;
+                    logger.ForContext<DateTime>().Write(Some.InformationEvent());
+                    Assert.Null(evt);
+                    logger.ForContext<DateTime>().Write(Some.WarningEvent());
+                    Assert.NotNull(evt);
+
+                    evt = null;
+                    logger.ForContext<CollectionBase>().Write(Some.WarningEvent());
+                    Assert.Null(evt);
+                    logger.ForContext<CollectionBase>().Write(Some.ErrorEvent());
+                    Assert.NotNull(evt);
+                });
+        }
+
+        [Fact]
+        public void PropertyEnrichment()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .Enrich.WithProperty("Property1", "PropertyValue1", /*destructureObjects*/ false)
+                .Enrich.WithProperty("Property2", "PropertyValue2", /*destructureObjects*/ false);
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.NotNull(evt);
+                    Assert.Equal("PropertyValue1", evt.Properties["Property1"].LiteralValue());
+                    Assert.Equal("PropertyValue2", evt.Properties["Property2"].LiteralValue());
+                });
+        }
+
+        [Fact]
+        public void LogContextEnrichment()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .Enrich.FromLogContext();
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+                    using (LogContext.PushProperty("Property", "Value1"))
+                    {
+                        logger.Write(Some.InformationEvent());
+                    }
+                    Assert.NotNull(evt);
+                    Assert.Equal("Value1", evt.Properties["Property"].LiteralValue());
+
+                    evt = null;
+
+                    using (LogContext.PushProperty("Property", "Value2"))
+                    {
+                        logger.Write(Some.InformationEvent());
+                    }
+                    Assert.NotNull(evt);
+                    Assert.Equal("Value2", evt.Properties["Property"].LiteralValue());
+                });
+        }
+
+        [Fact]
+        public void ExtensionMethodEnrichment()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .Enrich.WithDummyThreadId()
+                .Enrich.WithDummyUserName("MyUserName");
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.NotNull(evt);
+                    Assert.Equal("MyUserName", evt.Properties[DummyUserNameEnricher.PropertyName].LiteralValue());
+                    Assert.NotNull(evt.Properties[DummyThreadIdEnricher.PropertyName].LiteralValue());
+                });
+        }
+
+        [Fact]
+        public void WriteToSinkWithSimpleParams()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .WriteTo.DummyRollingFile(
+                    /*pathFormat*/ @"C:\toto.log",
+                    /*restrictedToMinimumLevel*/ LogEventLevel.Verbose,
+                    /*outputTemplate*/ null,
+                    /*formatProvider*/ null);
+
+            DummyRollingFileSink.Reset();
+
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc => lc,
+                test: (testCase, logger) =>
+                {
+                    logger.Write(Some.InformationEvent());
+                    Assert.NotNull(DummyRollingFileSink.Emitted.FirstOrDefault());
+                    Assert.Equal(@"C:\toto.log", DummyRollingFileSink.PathFormat);
+                    Assert.Null(DummyRollingFileSink.OutputTemplate);
+                    DummyRollingFileSink.Reset();
+                });
+        }
+
+        [Fact]
+        public void AuditToSinkWithSimpleParams()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .AuditTo.DummyRollingFile(
+                    /*pathFormat*/ @"C:\toto.log",
+                    /*restrictedToMinimumLevel*/ LogEventLevel.Verbose,
+                    /*outputTemplate*/ null,
+                    /*formatProvider*/ null);
+
+            DummyRollingFileAuditSink.Reset();
+
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc => lc,
+                test: (testCase, logger) =>
+                {
+
+                    logger.Write(Some.InformationEvent());
+                    Assert.NotNull(DummyRollingFileAuditSink.Emitted.FirstOrDefault());
+                    Assert.Equal(@"C:\toto.log", DummyRollingFileAuditSink.PathFormat);
+                    Assert.Null(DummyRollingFileAuditSink.OutputTemplate);
+                    DummyRollingFileAuditSink.Reset();
+                });
+        }
+
+        [Fact]
+        public void FilterExpression()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .Filter.ByExcluding("filter = 'exclude'");
+
+            LogEvent evt = null;
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc =>
+                {
+                    evt = null;
+                    return lc.WriteTo.Sink(new DelegatingSink(e => evt = e));
+                },
+                test: (testCase, logger) =>
+                {
+
+                    logger.ForContext("filter", "exclude").Information("This will not be logged because filter = exclude is set");
+                    Assert.Null(evt);
+
+                    logger.ForContext("filter", "keep it !").Information("This will be logged because filter will let it through");
+                    Assert.NotNull(evt);
+                });
+        }
+
+        [Fact]
+        public void AbstractTypeOrInterfaceImplementationsWithDefaultConstructor()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                .WriteTo.DummyWithFormatter(LogEventLevel.Verbose, new MyCustomTextFormatter())
+                .WriteTo.DummyConsole(LogEventLevel.Verbose, new MyCustomConsoleTheme())
+                ;
+
+            DummySink.Reset();
+            DummyConsoleSink.Reset();
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc => lc,
+                test: (testCase, logger) =>
+                {
+                    Assert.NotNull(DummySink.Formatter);
+                    Assert.IsType<MyCustomTextFormatter>(DummySink.Formatter);
+
+                    Assert.NotNull(DummyConsoleSink.Theme);
+                    Assert.IsType<MyCustomConsoleTheme>(DummyConsoleSink.Theme);
+
+                    DummySink.Reset();
+                    DummyConsoleSink.Reset();
+                });
+        }
+
+        [Fact]
+        public void AbstractTypeOrInterfaceImplementationsThroughPublicStaticProperty()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                    .WriteTo.DummyWithFormatter(LogEventLevel.Verbose, CustomFormatters.Formatter)
+                    .WriteTo.DummyConsole(LogEventLevel.Verbose, ConsoleThemes.Theme1)
+                ;
+
+            DummySink.Reset();
+            DummyConsoleSink.Reset();
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc => lc,
+                test: (testCase, logger) =>
+                {
+                    Assert.NotNull(DummySink.Formatter);
+                    Assert.Equal(CustomFormatters.Formatter, DummySink.Formatter);
+
+                    Assert.NotNull(DummyConsoleSink.Theme);
+                    Assert.Equal(ConsoleThemes.Theme1, DummyConsoleSink.Theme);
+
+                    DummySink.Reset();
+                    DummyConsoleSink.Reset();
+                });
+        }
+
+        [Fact]
+        public void AbstractTypeOrInterfaceImplementationsThroughPublicStaticField()
+        {
+            ConfigExpr expressionToTest = lc => lc
+                    .WriteTo.DummyWithFormatter(LogEventLevel.Verbose, CustomFormatters.FormatterField)
+                    .WriteTo.DummyConsole(LogEventLevel.Verbose, ConsoleThemes.Theme1Field)
+                ;
+
+            DummySink.Reset();
+            DummyConsoleSink.Reset();
+            TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(expressionToTest,
+                arrange: lc => lc,
+                test: (testCase, logger) =>
+                {
+                    Assert.NotNull(DummySink.Formatter);
+                    Assert.Equal(CustomFormatters.FormatterField, DummySink.Formatter);
+
+                    Assert.NotNull(DummyConsoleSink.Theme);
+                    Assert.Equal(ConsoleThemes.Theme1Field, DummyConsoleSink.Theme);
+
+                    DummySink.Reset();
+                    DummyConsoleSink.Reset();
+                });
+        }
+
+        void TestThatReadFromExpressionBehavesTheSameAsLoggerConfig(
+            ConfigExpr expressionToTest,
+            Func<LoggerConfiguration, LoggerConfiguration> arrange,
+            Action<string, Logger> test
+            )
+        {
+            var testCase = "Traditional";
+            var loggerConfiguration = expressionToTest.Compile().Invoke(new LoggerConfiguration());
+            loggerConfiguration = arrange(loggerConfiguration);
+            var logger = loggerConfiguration.CreateLogger();
+
+            test(testCase, logger);
+
+            testCase = "ConfigExpression";
+            var expressionLoggerConfiguration = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder.AddExpression(expressionToTest));
+            expressionLoggerConfiguration = arrange(expressionLoggerConfiguration);
+            var expressionLogger = expressionLoggerConfiguration.CreateLogger();
+
+            test(testCase, expressionLogger);
+        }
+    }
+}

--- a/test/Serilog.Settings.Combined.Tests/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializerTests.cs
+++ b/test/Serilog.Settings.Combined.Tests/Settings/ConfigExpression/ConfigurationExpressionSettingsSerializerTests.cs
@@ -1,0 +1,346 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Events;
+using Serilog.Settings.Combined.Tests.Support;
+using Serilog.Settings.Combined.Tests.Support.Formatting;
+using TestDummies;
+using TestDummies.Console.Themes;
+using Xunit;
+
+namespace Serilog.Settings.ConfigExpression.Tests
+{
+    public class ConfigurationExpressionSettingsSerializerTests
+    {
+        [Fact]
+        public void SupportMinimumLevel()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .MinimumLevel.Verbose()
+                        .MinimumLevel.Debug()
+                        .MinimumLevel.Information()
+                        .MinimumLevel.Warning()
+                        .MinimumLevel.Error()
+                        .MinimumLevel.Fatal()
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("minimum-level", "Verbose"),
+                new KeyValuePair<string, string>("minimum-level", "Debug"),
+                new KeyValuePair<string, string>("minimum-level", "Information"),
+                new KeyValuePair<string, string>("minimum-level", "Warning"),
+                new KeyValuePair<string, string>("minimum-level", "Error"),
+                new KeyValuePair<string, string>("minimum-level", "Fatal")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportMinimumLevelIs()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .MinimumLevel.Is(LogEventLevel.Verbose)
+                        .MinimumLevel.Is(LogEventLevel.Debug)
+                        .MinimumLevel.Is(LogEventLevel.Information)
+                        .MinimumLevel.Is(LogEventLevel.Warning)
+                        .MinimumLevel.Is(LogEventLevel.Error)
+                        .MinimumLevel.Is(LogEventLevel.Fatal)
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("minimum-level", "Verbose"),
+                new KeyValuePair<string, string>("minimum-level", "Debug"),
+                new KeyValuePair<string, string>("minimum-level", "Information"),
+                new KeyValuePair<string, string>("minimum-level", "Warning"),
+                new KeyValuePair<string, string>("minimum-level", "Error"),
+                new KeyValuePair<string, string>("minimum-level", "Fatal")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportMinimumLevelOverrides()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .MinimumLevel.Override("Foo", LogEventLevel.Error)
+                        .MinimumLevel.Override("Bar.Qux", LogEventLevel.Warning)
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("minimum-level:override:Foo", "Error"),
+                new KeyValuePair<string, string>("minimum-level:override:Bar.Qux", "Warning")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportEnrichWithProperty()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .Enrich.WithProperty("Prop1", "Prop1Value", false)
+                        .Enrich.WithProperty("Prop2", 42, false)
+                        .Enrich.WithProperty("Prop3", new Uri("https://www.perdu.com/bar"), false)
+                        .Enrich.WithProperty("Prop4", true, false)
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("enrich:with-property:Prop1", "Prop1Value"),
+                new KeyValuePair<string, string>("enrich:with-property:Prop2", "42"),
+                new KeyValuePair<string, string>("enrich:with-property:Prop3", "https://www.perdu.com/bar"),
+                new KeyValuePair<string, string>("enrich:with-property:Prop4", "True"),
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportEnrichWithExtensionMethod()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc.Enrich.WithDummyThreadId()
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("enrich:WithDummyThreadId", "")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+
+        [Fact]
+        public void SupportEnrichFromLogContext()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc.Enrich.FromLogContext()
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                // no using because method defined in the Core Serilog assembly
+                new KeyValuePair<string, string>("enrich:FromLogContext", "")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportWriteTo()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc.WriteTo.DummyRollingFile(
+                            @"C:\toto.log",
+                            LogEventLevel.Warning,
+                            null,
+                            null)
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyRollingFile.pathFormat", @"C:\toto.log"),
+                new KeyValuePair<string, string>("write-to:DummyRollingFile.restrictedToMinimumLevel", "Warning")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportAuditTo()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .AuditTo.DummyRollingFile(
+                            @"C:\toto.log",
+                            LogEventLevel.Warning,
+                            null,
+                            null)
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("audit-to:DummyRollingFile.pathFormat", @"C:\toto.log"),
+                new KeyValuePair<string, string>("audit-to:DummyRollingFile.restrictedToMinimumLevel", "Warning")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportFilter()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc.Filter.ByExcluding("filter = 'exclude'")
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:Serilog.Filters.Expressions", "Serilog.Filters.Expressions"),
+                new KeyValuePair<string, string>("filter:ByExcluding.expression", "filter = 'exclude'"),
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForDefaultConstuctorOfConcreteImplOfAbstractClass()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyConsole(
+                            LogEventLevel.Verbose,
+                            new MyCustomConsoleTheme()
+                            )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.restrictedToMinimumLevel", "Verbose"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.theme", typeof(MyCustomConsoleTheme).AssemblyQualifiedName)
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForDefaultConstuctorOfConcreteImplOfInterface()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyRollingFile(
+                            /*ITextFormatter*/ new MyCustomTextFormatter(),
+                            /*pathFormat*/ "path",
+                            LogEventLevel.Verbose
+                        )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyRollingFile.formatter", typeof(MyCustomTextFormatter).AssemblyQualifiedName),
+                new KeyValuePair<string, string>("write-to:DummyRollingFile.pathFormat", "path"),
+                new KeyValuePair<string, string>("write-to:DummyRollingFile.restrictedToMinimumLevel", "Verbose")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForStaticPropertyForAbstractClassTypedParameters()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyConsole(
+                            LogEventLevel.Verbose,
+                            /*ConsoleTheme*/ ConsoleThemes.Theme1
+                        )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.restrictedToMinimumLevel", "Verbose"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.theme", $"{typeof(ConsoleThemes).FullName}::{nameof(ConsoleThemes.Theme1)}, {typeof(ConsoleThemes).Assembly.FullName}")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForStaticPropertyForInterfaceTypedParameters()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyWithFormatter(
+                            LogEventLevel.Verbose,
+                            /*formatter*/ CustomFormatters.Formatter
+                        )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyWithFormatter.restrictedToMinimumLevel", "Verbose"),
+                new KeyValuePair<string, string>("write-to:DummyWithFormatter.formatter", $"{typeof(CustomFormatters).FullName}::{nameof(CustomFormatters.Formatter)}, {typeof(CustomFormatters).Assembly.FullName}")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForStaticFieldForAbstractClassTypedParameters()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyConsole(
+                            LogEventLevel.Verbose,
+                            /*ConsoleTheme*/ ConsoleThemes.Theme1Field
+                        )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.restrictedToMinimumLevel", "Verbose"),
+                new KeyValuePair<string, string>("write-to:DummyConsole.theme", $"{typeof(ConsoleThemes).FullName}::{nameof(ConsoleThemes.Theme1Field)}, {typeof(ConsoleThemes).Assembly.FullName}")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        [Fact]
+        public void SupportForStaticFieldForInterfaceTypedParameters()
+        {
+            var actual = new ConfigurationExpressionSettingsSerializer()
+                .SerializeToKeyValuePairs(lc =>
+                    lc
+                        .WriteTo.DummyWithFormatter(
+                            LogEventLevel.Verbose,
+                            /*formatter*/ CustomFormatters.FormatterField
+                        )
+                ).ToList();
+
+            var expected = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("using:TestDummies", "TestDummies"),
+                new KeyValuePair<string, string>("write-to:DummyWithFormatter.restrictedToMinimumLevel", "Verbose"),
+                new KeyValuePair<string, string>("write-to:DummyWithFormatter.formatter", $"{typeof(CustomFormatters).FullName}::{nameof(CustomFormatters.FormatterField)}, {typeof(CustomFormatters).Assembly.FullName}")
+            };
+
+            Assert.Equal(expected.ToList(), actual, new KeyValuePairComparer<string, string>());
+        }
+
+        // TODO : special handling of "default" value of parameters -> do not generate a kvp in that case ?
+        // TODO : special custom conversions (TimeSpan etc ? )
+        // TODO : support for default constructor ... including when there is no default constructor, but there is one with only default parameters ...
+    }
+}


### PR DESCRIPTION
Second part of #5 : generate key-value settings from an `Expression<Func<LoggerConfiguration, LoggerConfiguration>>`

Most of the work is in class `ConfigurationExpressionSettingsSerializer`.

Currently supported features : 
- `MinimumLevel.Is()` / `MinimumLevel.{Level}()` / `MinimumLevel.Override()`
- `Enrich.WithProperty()`
- `Enrich.{ExtensionMethod}()`
- `WriteTo.{ExtensionMethod}()`
- `AuditTo.{ExtensionMethod}()`
- `Filter.{ExtensionMethod}()`

Currently supported "parameters" : 
- constant expressions
- `new Class()` where `Class` inherits/implements an abstract class / interface
- `public static` property / field to acces an abstract class / interface

Tests : 
- expression serilization tests
- sanity checks (`AddExpression(exp)` behaves the same as applying the expression)
- combination tests (combines different settings sources)

Known advanced missing features as TODOs in `ConfigurationExpressionSettingsSerializerTests.cs` , but they should probably be included in future separate PRs.

Note: this PR sits on top of #9 , so I will rebase it properly once #9 has been merged .